### PR TITLE
removes form from index.erb

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -1,9 +1,1 @@
 <h1>Welcome!</h1>
-
-<form action="/greet" method="POST">
-  <label for="user_name">Name:</label>
-
-  <p><input type="text" name="user_name" id="user_name" /></p>
-
-  <input type="submit" value="Submit"/>
-</form>


### PR DESCRIPTION
This form should be added after running the second test and having it fail.  As it is, the test passes immediately once written because the form is already inside of index.erb.  Instructions for adding the form to index.erb are in the README.md, so there is no need for the code to already be inside of index.erb.