### PR TITLE
removes post '/greet' route from app.rb

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,7 +4,4 @@ class Application < Sinatra::Base
     erb :index
   end
 
-  post '/greet' do
-    erb :greet
-  end
 end


### PR DESCRIPTION
This route should be left out of the original repository as we have instructions in the README.md to add it in order to pass the Third test.